### PR TITLE
Fix CRT-Glow.

### DIFF
--- a/CRT-Glow.shader/gauss_horiz.fs
+++ b/CRT-Glow.shader/gauss_horiz.fs
@@ -18,7 +18,7 @@ out vec4 FragColor;
 void main() {
    float texel      = floor(data_pix_no);
    float phase      = data_pix_no - texel;
-   float base_phase = phase.x - 0.5;
+   float base_phase = phase - 0.5;
    vec2 tex         = vec2((texel + 0.5) * sourceSize[0].z, vTexCoord.y);
 
    vec3 col = vec3(0.0);


### PR DESCRIPTION
With bsnes CRT-Glow will produce a white screen and the following error.
```
[ruby::OpenGL: shader compiler error]
0:21(21): error: cannot access field `x' of non-structure / non-vector
0:21(21): error: type mismatch
0:21(21): error: operands to arithmetic operators must be numeric
0:27(16): warning: `base_phase' used uninitialized
```
Please review this to make sure its right, I'm not sure what the shader should look like, just now that its not a white screen and doesn't produce errors.